### PR TITLE
console: Add support for dec and hex output

### DIFF
--- a/source/core/main.cpp
+++ b/source/core/main.cpp
@@ -18,17 +18,11 @@ extern "C"
 
 static void Main(void)
 {
-	//console_init();
-	//console_msg("\r\n > console enabled\r\n");
-
 	device::UartPl011 Uart;
-
 	Uart.Init();
-//	console_init();
-//	console_msg("\r\n > console enabled\r\n");
 
 	Console c(Uart);
-	c << "Hey!";
+	c << "Console test: " << 1234 << " = 0x" << fmt::hex << fmt::fill << 1234 << fmt::endl;
 
 	for (;;);
 }

--- a/source/include/console
+++ b/source/include/console
@@ -8,8 +8,11 @@ namespace core {
 using namespace device;
 
 enum class fmt {
-	endl,
-	hex
+	dec,		// Display integers in decimal format
+	endl,		// Line break and carier return
+	hex,		// Display integers in heximal format
+	fill,		// Fill number displaying by '0' till 8 digits in total
+	nofill		// Disable filling the number by '0'
 };
 
 class Console
@@ -23,10 +26,14 @@ public:
 
 public:
 	Console& operator<<(char const *msg);
+	Console& operator<<(int num);
+	Console& operator<<(unsigned long num);
 	Console& operator<<(fmt format);
 
 private:
 	bool isActive;
+	bool isHex;
+	bool isFill;
 	UartDevice& uart;
 };
 


### PR DESCRIPTION
This patch adds support to console to display numbers in decimal and heximal formats.

Signed-off-by: Alexander Smirnov <alex.bluesman.smirnov@gmail.com>