### PR TITLE
12 implement operator new using heap

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,7 +1,7 @@
 MACHINE := qemuarm64
 
 AFLAGS += -I$(TOP_DIR)/source/include
-CFLAGS += -I$(TOP_DIR)/source/include -fno-rtti 
+CFLAGS += -I$(TOP_DIR)/source/include -fno-rtti -fno-exceptions
 
 # Toolchain parameters
 AS      = $(CROSS_COMPILE)as

--- a/source/boot/head.S
+++ b/source/boot/head.S
@@ -78,7 +78,7 @@ smp_entry:
 	early_print("         .. . .\"'\r\n")
 	early_print("        .\r\n")
 
-	early_print(" - Project Saturn 2019 -\r\n\n")
+	early_print(" - Project Saturn 2023 -\r\n\n")
 
 	early_print(" > physical start: 0x")
 	adr	x0, start

--- a/source/core/heap.cpp
+++ b/source/core/heap.cpp
@@ -122,7 +122,21 @@ void Heap::Free(void *base)
 	{
 		Heap_Free_Block<Data_Block<16>>(&List16_Available, &List16_Allocated, base);
 	}
-	//TBD
+	else
+	if (base <= &Data32[_heap_size])
+	{
+		Heap_Free_Block<Data_Block<32>>(&List32_Available, &List32_Allocated, base);
+	}
+	else
+	if (base <= &Data48[_heap_size])
+	{
+		Heap_Free_Block<Data_Block<48>>(&List48_Available, &List48_Allocated, base);
+	}
+	else
+	if (base <= &Data64[_heap_size])
+	{
+		Heap_Free_Block<Data_Block<64>>(&List64_Available, &List64_Allocated, base);
+	}
 }
 
 void Heap::State(IConsole& console)


### PR DESCRIPTION
This pull request introduces overloaded 'new' and 'delete' operators, which work on top of Saturn heap implementation. Now we don't need to create objects on the stack.