### PR TITLE
26 bug memory mapping works for the first page only

### DIFF
--- a/source/core/console.cpp
+++ b/source/core/console.cpp
@@ -7,18 +7,33 @@ using namespace device;
 
 static const size_t max_message_size = 128;
 
+Console::Console()
+	: isActive(false)
+	, isHex(false)
+	, isFill(false)
+	, uart(nullptr)
+{
+	*this << fmt::endl << "<console enabled>" << fmt::endl << fmt::endl;
+}
+
 Console::Console(UartDevice& u)
 	: isActive(false)
 	, isHex(false)
 	, isFill(false)
-	, uart(u)
+	, uart(&u)
 {
 	isActive = true;
 	*this << fmt::endl << "<console enabled>" << fmt::endl << fmt::endl;
 }
 
-//void * Console::operator new(long unsigned int size)
-//{}
+
+void Console::RegisterUart(UartDevice& u)
+{
+	uart = &u;
+	isActive = true;
+
+	// TBD: flush buffered output
+}
 
 Console& Console::operator<<(char const *msg)
 {
@@ -53,7 +68,7 @@ Console& Console::operator<<(char const *msg)
 
 	if (isActive)
 	{
-		uart.Tx(buf, len);
+		uart->Tx(buf, len);
 	}
 
 	return *this;

--- a/source/core/console.hpp
+++ b/source/core/console.hpp
@@ -15,6 +15,7 @@ class Console : public IConsole
 //	void operator delete(void * p, unsigned long){};
 
 public:
+	Console();
 	Console(UartDevice&);
 
 public:
@@ -28,6 +29,9 @@ public:
 
 	Console& operator<<(size_t num);
 
+public:
+	void RegisterUart(UartDevice&);
+
 private:
 	Console& SignedToStr(int64_t num, uint8_t fillSize = 0);
 	Console& UnsignedToStr(uint64_t num, uint8_t fillSize = 0);
@@ -36,7 +40,7 @@ private:
 	bool isActive;
 	bool isHex;
 	bool isFill;
-	UartDevice& uart;
+	UartDevice* uart;
 };
 
 }; // namespace core

--- a/source/core/main.cpp
+++ b/source/core/main.cpp
@@ -34,10 +34,15 @@ static void Main(void)
 	Heap Main_Heap;
 	Saturn_Heap = &Main_Heap;
 
+	// Let's create console as soon as possible to be able to collect output from MMU.
+	// It has no connection to UART, but it could buffer the output and flush it later.
+	// Also let's keep heap initialization before, we could use it for buffering.
+	Saturn_Console = new Console();
+
 	Saturn_MMU = new MemoryManagementUnit();
 
 	device::UartPl011& Uart = *new device::UartPl011();
-	Saturn_Console = new Console(Uart);
+	Saturn_Console->RegisterUart(Uart);
 
 	Exceptions_Init();
 

--- a/source/core/mmu.cpp
+++ b/source/core/mmu.cpp
@@ -2,6 +2,7 @@
 
 // TBD: rework it
 #include <asm/mmu.h>
+#include <fault>
 
 using namespace saturn::core;
 
@@ -25,7 +26,9 @@ MemoryManagementUnit::MemoryManagementUnit()
 	, PTable2(ptable_l2)
 	, PTable3(ptable_l3)
 	, FreeMaskL3(0)
-{}
+{
+	Log() << "memory management unit initialized" << fmt::endl;
+}
 
 uint16_t MemoryManagementUnit::FindFreeL3(void)
 {
@@ -42,7 +45,7 @@ uint16_t MemoryManagementUnit::FindFreeL3(void)
 
 	if (i == _l3_tables)
 	{
-		// TBD: die here
+		Fault("mmu: no free L3 tables left");
 	}
 
 	return i;
@@ -142,6 +145,12 @@ void MemoryManagementUnit::MemoryMap(uint64_t base_addr, size_t size, MMapType t
 	while (start < end);
 
 	// TBD: update TLB and data caches here
+//	asm volatile("\
+//			dsb	ishst;	\
+//			tlbi	alle2;	\
+//			dsb	ish;	\
+//			isb;		\
+//	             " : : : "memory");
 }
 
 void MemoryManagementUnit::MemoryUnmap(uint64_t base_addr, size_t size)


### PR DESCRIPTION
The problem was caused by incorrect QEMU configuration, so the was no GICv3 available. This patch set changes the configuration, so there is no data abort anymore and GICv3 I/O registers available.