### PR TITLE
core: Unify the way to manage global objects

### DIFF
--- a/source/core/console.hpp
+++ b/source/core/console.hpp
@@ -12,8 +12,8 @@
 
 #pragma once
 
+#include <core/iconsole>
 #include <dev/uart>
-#include <iconsole>
 
 namespace saturn {
 namespace core {

--- a/source/core/cpu.cpp
+++ b/source/core/cpu.cpp
@@ -13,12 +13,10 @@
 #include "cpu.hpp"
 
 #include <arm64/registers>
-#include <iconsole>
+#include <core/iconsole>
 
 namespace saturn {
 namespace core {
-
-static CpuInfo* Local_CPU = nullptr;
 
 CpuInfo::CpuInfo()
 {
@@ -44,16 +42,6 @@ CpuInfo::CpuInfo()
 uint64_t CpuInfo::Id()
 {
 	return CoreId;
-}
-
-void Register_CPU()
-{
-	Local_CPU = new CpuInfo();
-}
-
-ICpuInfo* This_CPU()
-{
-	return Local_CPU;
 }
 
 }; // namespace core

--- a/source/core/cpu.hpp
+++ b/source/core/cpu.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <icpu>
+#include <core/icpu>
 
 namespace saturn {
 namespace core {

--- a/source/core/exceptions.cpp
+++ b/source/core/exceptions.cpp
@@ -13,14 +13,13 @@
 #include "ic/ic_core.hpp"
 
 #include <arm64/registers>
-#include <iconsole>
+#include <core/iconsole>
+#include <core/iirq>
 
 extern saturn::uint64_t saturn_vector;
 
 namespace saturn {
 namespace core {
-
-extern IC_Core* Saturn_IC;
 
 void Exceptions_Init()
 {
@@ -112,7 +111,7 @@ void System_Error(struct AArch64_Regs* Regs)
 
 void IRq_Handler(struct AArch64_Regs* Regs)
 {
-	core::Saturn_IC->Handle_IRq();
+	core::IC().Handle_IRq();
 }
 
 } // extern "C"

--- a/source/core/heap.cpp
+++ b/source/core/heap.cpp
@@ -10,9 +10,10 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the 
 // specific language governing permissions and limitations under the License.
 
-#include <system>
-
 #include "heap.hpp"
+
+#include <core/iconsole>
+#include <system>
 
 namespace saturn {
 namespace core {

--- a/source/core/heap.hpp
+++ b/source/core/heap.hpp
@@ -12,8 +12,7 @@
 
 #pragma once
 
-#include <iconsole>
-#include <iheap>
+#include <core/iheap>
 #include <list>
 
 namespace saturn {

--- a/source/core/ic/gic/cpu_interface.cpp
+++ b/source/core/ic/gic/cpu_interface.cpp
@@ -13,7 +13,7 @@
 #include "cpu_interface.hpp"
 
 #include <arm64/registers>
-#include <iconsole>
+#include <core/iconsole>
 
 namespace saturn {
 namespace core {

--- a/source/core/ic/gic/distributor.cpp
+++ b/source/core/ic/gic/distributor.cpp
@@ -13,7 +13,7 @@
 #include "distributor.hpp"
 
 #include <arm64/registers>
-#include <icpu>
+#include <core/icpu>
 #include <fault>
 #include <platform/qemuarm64>
 
@@ -84,7 +84,7 @@ GicDistributor::GicDistributor()
 	Regs->Write<uint32_t>(Gic_Dist::CTRL, (1 << 4) | (1 << 1) | (1 << 0)); // EnableGrp0 | EnableGrp1NS | ARE_NS
 
 	// TBD: let's assume that we have only 16 cores maximum, so the only Aff0 is used
-	uint32_t affinity = This_CPU()->Id() & 0x7;
+	uint32_t affinity = This_CPU().Id() & 0x7;
 
 	// Disable broadcast rounting
 	affinity &= ~(1 << 31);

--- a/source/core/ic/gic/redistributor.cpp
+++ b/source/core/ic/gic/redistributor.cpp
@@ -13,7 +13,7 @@
 #include "redistributor.hpp"
 
 #include <arm64/registers>
-#include <iconsole>
+#include <core/iconsole>
 #include <platform/qemuarm64>
 
 namespace saturn {

--- a/source/core/ic/ic_core.hpp
+++ b/source/core/ic/ic_core.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <iirq>
+#include <core/iirq>
 
 namespace saturn {
 namespace core {

--- a/source/core/main.hpp
+++ b/source/core/main.hpp
@@ -1,0 +1,78 @@
+// Copyright (C) 2023 Alexander Smirnov <alex.bluesman.smirnov@gmail.com>
+//
+// Licensed under the MIT License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include "console.hpp"
+#include "cpu.hpp"
+#include "heap.hpp"
+#include "ic/ic_core.hpp"
+#include "mmu.hpp"
+
+namespace saturn {
+namespace core {
+
+// Saturn core components:
+static Heap* 			Saturn_Heap = nullptr;		// Heap object pointer to implement operators new/delete
+static MemoryManagementUnit* 	Saturn_MMU = nullptr;		// MMU object pointer to implement I/O mapping
+static Console* 		Saturn_Console = nullptr;	// Console pointer for trace and logging
+static IC_Core*			Saturn_IC = nullptr;		// Interrupt controller pointer for IRq management
+static CpuInfo*			Local_CPU = nullptr;		// CPU information pointer
+
+
+// Access to global core components:
+//  - Console			(Log)
+//  - Interrupt Controller	(IC)
+//  - Memory Management		(MMU)
+//  - Heap			(Allocator)
+
+IConsole& Log(void)
+{
+	return *Saturn_Console;
+}
+
+IIC& IC(void)
+{
+	return *Saturn_IC;
+}
+
+IMemoryManagementUnit& MMU(void)
+{
+	return *Saturn_MMU;
+}
+
+IHeap& Allocator(void)
+{
+	return *Saturn_Heap;
+}
+
+ICpuInfo& This_CPU(void)
+{
+	return *Local_CPU;
+}
+
+}; // namespace core
+}; // namespace saturn
+
+
+// Overload operators 'new' and 'delete' to use Saturn heap
+using namespace saturn;
+
+void* operator new(size_t size) noexcept
+{
+	return saturn::core::Allocator().Alloc(size);
+}
+
+void operator delete(void* base, size_t size) noexcept
+{
+	return saturn::core::Allocator().Free(base);
+}

--- a/source/core/mmu.hpp
+++ b/source/core/mmu.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <immu>
+#include <core/immu>
 #include <system>
 
 namespace saturn {

--- a/source/include/core/iconsole
+++ b/source/include/core/iconsole
@@ -41,7 +41,8 @@ public:
 	virtual IConsole& operator<<(size_t num) = 0;
 };
 
-IConsole& Log();
+// Access to console
+IConsole& Log(void);
 
 }; // namespace core
 }; // namespace saturn

--- a/source/include/core/icpu
+++ b/source/include/core/icpu
@@ -17,22 +17,14 @@
 namespace saturn {
 namespace core {
 
-using IRqHandler = void(*)(uint32_t);
-
-// Forward declaration
-class CpuInterface;
-class GicDistributor;
-class GicRedistributor;
-
-class IIC
+class ICpuInfo
 {
 public:
-	virtual void Local_IRq_Disable() = 0;
-	virtual void Local_IRq_Enable() = 0;
-	virtual void Send_SGI(uint32_t, uint8_t) = 0;
-	virtual void Handle_IRq() = 0;
-	virtual void Register_IRq_Handler(uint32_t, IRqHandler) = 0;
+	virtual uint64_t Id() = 0;	
 };
+
+// Access to CPU interface
+ICpuInfo& This_CPU(void);
 
 }; // namespace core
 }; // namespace saturn

--- a/source/include/core/iheap
+++ b/source/include/core/iheap
@@ -24,5 +24,8 @@ public:
 	virtual void	Free(void *base) = 0;
 };
 
+// Access to heap
+IHeap& Allocator(void);
+
 }; // namespace core
 }; // namespace saturn

--- a/source/include/core/iirq
+++ b/source/include/core/iirq
@@ -17,13 +17,20 @@
 namespace saturn {
 namespace core {
 
-class ICpuInfo
+using IRqHandler = void(*)(uint32_t);
+
+class IIC
 {
 public:
-	virtual uint64_t Id() = 0;	
+	virtual void Local_IRq_Disable() = 0;
+	virtual void Local_IRq_Enable() = 0;
+	virtual void Send_SGI(uint32_t, uint8_t) = 0;
+	virtual void Handle_IRq() = 0;
+	virtual void Register_IRq_Handler(uint32_t, IRqHandler) = 0;
 };
 
-ICpuInfo* This_CPU();
+// Access to interrupt controller
+IIC& IC(void);
 
 }; // namespace core
 }; // namespace saturn

--- a/source/include/core/immu
+++ b/source/include/core/immu
@@ -15,6 +15,7 @@
 #include <basetypes>
 
 namespace saturn {
+namespace core {
 
 // Memory mapping types:
 enum class MMapType {
@@ -28,4 +29,8 @@ public:
 	virtual void MemoryUnmap(uint64_t base_addr, size_t size) = 0;
 };
 
+// Access to memory management unit
+IMemoryManagementUnit& MMU(void);
+
+}; // namespace core
 }; // namespace saturn

--- a/source/include/fault
+++ b/source/include/fault
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <iconsole>
+#include <core/iconsole>
 #include <io>
 
 namespace saturn {

--- a/source/include/mmap
+++ b/source/include/mmap
@@ -12,14 +12,10 @@
 
 #pragma once
 
-#include <immu>
+#include <core/immu>
 #include <io>
 
 namespace saturn {
-
-namespace core {
-	extern IMemoryManagementUnit* Saturn_MMU;
-}; // namespace core
 
 class MMap {
 public:
@@ -30,19 +26,19 @@ public:
 	};
 
 public:
-	MMap(const IO_Region& io, MMapType type = MMapType::Device)
+	MMap(const IO_Region& io, core::MMapType type = core::MMapType::Device)
 		: Base(io.Base)
 		, Size(io.Size)
 		, Type(type)
 	{
 		// TBD: check return value
-		core::Saturn_MMU->MemoryMap(Base, Size, Type);
+		core::MMU().MemoryMap(Base, Size, Type);
 	};
 
 	~MMap()
 	{
 		// TBD: check return value
-		core::Saturn_MMU->MemoryUnmap(Base, Size);
+		core::MMU().MemoryUnmap(Base, Size);
 	};
 
 public:
@@ -61,7 +57,7 @@ public:
 private:
 	uint64_t	Base;
 	size_t		Size;
-	MMapType	Type;
+	core::MMapType	Type;
 };
 
 }; // namespace saturn


### PR DESCRIPTION
There are several global objects inside core like: MMU, Interrupt Controller, Console etc. and it's quite hard to pass references to them through class interfaces - this will lead to significant growth of complexity. That's why this patch introduces the following:
 - All the global object pointers are collected in one place
 - Objects are static and access to them provided using getters. This will prevent from object pointer corruption