### PR TITLE
console: Add support for key shortcuts

### DIFF
--- a/source/core/console.hpp
+++ b/source/core/console.hpp
@@ -23,6 +23,12 @@ using namespace device;
 static const size_t _rx_size = 16;
 static const size_t _tx_size = 1024;
 
+enum systemKeys
+{
+	cmdMode = 0x09,		// 'CTRL + i' enter command mode
+	cmdBeep = 0x62		// 'b': make a beep for testing purposes
+};
+
 class Console : public IConsole
 {
 public:
@@ -76,6 +82,8 @@ private:
 	// RX/TX buffering
 	RingBuffer<char, _rx_size> *rxBuffer;
 	RingBuffer<char, _tx_size> *txBuffer;
+
+	bool cmdMode;
 };
 
 }; // namespace core


### PR DESCRIPTION
This patch add a simple interface to talk to hypervisor using key shortcuts. To enter command mode please use CTRL + i. The only one command is supported for now, type 'b' - and hypervisor prints (beep) in console.